### PR TITLE
Add support for multiple telemetry links

### DIFF
--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -10,24 +10,27 @@ ExecStart=/usr/local/bin/polkadot \
   --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
   --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
   --rpc-methods=Unsafe \
-  {% if hostvars[inventory_hostname].polkadot_additional_common_flags is defined and hostvars[inventory_hostname].polkadot_additional_common_flags|length %}
+  {% if hostvars[inventory_hostname].polkadot_additional_common_flags is defined and hostvars[inventory_hostname].polkadot_additional_common_flags|length -%}
   {{ hostvars[inventory_hostname].polkadot_additional_common_flags }} \
-  {% endif %}
-  {% if hostvars[inventory_hostname].polkadot_additional_validator_flags is defined and hostvars[inventory_hostname].polkadot_additional_validator_flags|length %}
+  {% endif -%}
+  {% if hostvars[inventory_hostname].polkadot_additional_validator_flags is defined and hostvars[inventory_hostname].polkadot_additional_validator_flags|length -%}
   {{ hostvars[inventory_hostname].polkadot_additional_validator_flags }} \
-  {% endif %}
-  {% if hostvars[inventory_hostname].loggingFilter is defined and hostvars[inventory_hostname].loggingFilter|length %}
+  {% endif -%}
+  {% if hostvars[inventory_hostname].loggingFilter is defined and hostvars[inventory_hostname].loggingFilter|length -%}
   -l{{ hostvars[inventory_hostname].loggingFilter }} \
-  {% endif %}
-  --chain={{ chain }} \
-  {% if hostvars[inventory_hostname].base_path is defined and hostvars[inventory_hostname].base_path|length %}
+  {% endif -%}
+  {% if hostvars[inventory_hostname].base_path is defined and hostvars[inventory_hostname].base_path|length -%}
   --base-path '{{ hostvars[inventory_hostname].base_path }}' \
-  {% endif %}
-  {% if hostvars[inventory_hostname].telemetryUrl is defined and hostvars[inventory_hostname].telemetryUrl|length %}
-  --telemetry-url '{{ hostvars[inventory_hostname].telemetryUrl }} 1'
-  {% else %}
-  --no-telemetry
-  {% endif %}
+  {% endif -%}
+  {% if hostvars[inventory_hostname].telemetryUrl is defined and hostvars[inventory_hostname].telemetryUrl|length -%}
+  {% set telemetryUrls = hostvars[inventory_hostname].telemetryUrl.split(',') -%}
+  {% for telemetryUrl in telemetryUrls -%}
+  --telemetry-url '{{ telemetryUrl }} 1' \
+  {% endfor %}
+  {%- else -%}
+  --no-telemetry \
+  {% endif -%}
+  --chain={{ chain }}
 
 Restart=always
 RestartSec=60


### PR DESCRIPTION
Hello,

I created a PR to address https://github.com/w3f/polkadot-secure-validator/issues/59. This adds support for multiple telemetry links by having the user provide a comma separated list to the variable `telemetryUrl`. It leverages the same variable name to be backwards compatible with original variable and value.

This PR also cleans up the formatting of the service file by removing excess spacing that was caused by the conditional statements.

Example:
```
[all:vars]
telemetryUrl=wss://telemetry.polkadot.io/submit/,wss://telemetry-backend.w3f.community/submit
```

Will produce:
```
[Unit]
Description=Polkadot Node

[Service]
User=polkadot
Group=polkadot
ExecStart=/usr/local/bin/polkadot \
  --name mynamehere-sv-validator-0 \
  --validator \
  --public-addr=/ip4/servers.ip.address/tcp/80 \
  --listen-addr=/ip4/127.0.0.1/tcp/30333 \
  --rpc-methods=Unsafe \
  -lsync=warn,afg=warn,babe=warn \
  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 1' \
  --telemetry-url 'wss://telemetry-backend.w3f.community/submit 1' \
  --chain=kusama

Restart=always
RestartSec=60

[Install]
WantedBy=multi-user.target
```
Let me know if you have any concerns with this implementation and thank you for maintaning this repo!