### PR TITLE
Replace dash with underscore in Ansible inventory naming convention

### DIFF
--- a/GUIDE_ANSIBLE.md
+++ b/GUIDE_ANSIBLE.md
@@ -59,25 +59,25 @@ validator to a public server.
 
 ### Setup Validator
 
-Setup the validator node by specifying a `[validator-<NUM>]` host, including its
+Setup the validator node by specifying a `[validator_<NUM>]` host, including its
 required variables. `<NUM>` should start at `0` and increment for each other
 validator (assuming you have more than one validator).
 
 Example:
 
 ```ini
-[validator-0]
+[validator_0]
 147.75.76.65
 
-[validator-0:vars]
+[validator_0:vars]
 ansible_user=alice
 telemetryUrl=wss://telemetry.polkadot.io/submit/
 loggingFilter='sync=trace,afg=trace,babe=debug'
 
-[validator-1]
+[validator_1]
 162.12.35.55
 
-[validator-1:vars]
+[validator_1:vars]
 ansible_user=bob
 telemetryUrl=wss://telemetry.polkadot.io/submit/
 loggingFilter='sync=trace,afg=trace,babe=debug'
@@ -91,8 +91,8 @@ Example:
 
 ```ini
 [validator:children]
-validator-0
-validator-1
+validator_0
+validator_1
 ```
 
 ### Specify common variables

--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -2,10 +2,10 @@
 
 
 # ## Validator 0
-[validator-0]
+[validator_0]
 147.75.76.65
 
-[validator-0:vars]
+[validator_0:vars]
 ansible_user=alice
 # Preferably use a private telemetry server
 telemetryUrl=wss://telemetry.polkadot.io/submit/
@@ -13,10 +13,10 @@ loggingFilter='sync=warn,afg=warn,babe=warn'
 
 
 # ## Validator 1
-[validator-1]
+[validator_1]
 162.12.35.55
 
-[validator-1:vars]
+[validator_1:vars]
 ansible_user=bob
 # Preferably use a private telemetry server
 telemetryUrl=wss://telemetry.polkadot.io/submit/
@@ -25,8 +25,8 @@ loggingFilter='sync=warn,afg=warn,babe=warn'
 
 # ## Group all nodes
 [validator:children]
-validator-0
-validator-1
+validator_0
+validator_1
 
 
 # ## Common variables

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -1,8 +1,8 @@
 {{#each validators }}
-[validator-{{@index}}]
+[validator_{{@index}}]
 {{ this.ipAddress }}
 
-[validator-{{@index}}:vars]
+[validator_{{@index}}:vars]
 ansible_user={{ this.sshUser }}
 telemetryUrl={{ ../validatorTelemetryUrl }}
 loggingFilter='{{{ ../validatorLoggingFilter }}}'
@@ -12,7 +12,7 @@ nodeName={{ this.nodeName }}
 
 [validator:children]
 {{#each validators }}
-validator-{{@index}}
+validator_{{@index}}
 {{/each}}
 
 


### PR DESCRIPTION
Replace dash with underscore in Ansible inventory naming convention. For example, from `[validator-0]` to `[validator_0]`.

This change avoids printing the following warning when executing the Ansible script:

```bash
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in group names by default, this will change, but still be user configurable on deprecation. This feature will be removed in version 2.10. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
```