### PR TITLE
Update inventory.sample

### DIFF
--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -39,8 +39,8 @@ ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ConnectTimeout=15'
 build_dir=$HOME/.config/polkadot-secure-validator/build/w3f/ansible
 
 # Specify which `polkadot` binary to install. Checksum is verified during execution.
-polkadot_binary_url='https://github.com/paritytech/polkadot/releases/download/v0.8.2/polkadot'
-polkadot_binary_checksum='sha256:349b786476de9188b79817cab48fc6fc030908ac0e8e2a46a1600625b1990758'
+polkadot_binary_url='https://github.com/paritytech/polkadot/releases/download/v0.8.30/polkadot'
+polkadot_binary_checksum='sha256:9dddd2ede827865c6e81684a138b0f282319e07f717c166b92834699f43274cd'
 
 # Specify the chain/network.
 #


### PR DESCRIPTION
Updated the binary and hash to version 0.8.30.  Perhaps at the time of review this might change to 0.9.0 and might be worth waiting on

The older version does not sync and is not compatible with newer snapshots.