### PR TITLE
Check sha256 before download

### DIFF
--- a/ansible/roles/node-exporter/tasks/main.yml
+++ b/ansible/roles/node-exporter/tasks/main.yml
@@ -4,18 +4,27 @@
     state: directory
     mode: '0755'
 
+- name: get current node_exporter sha256
+  shell: |
+    sha256sum /root/node_exporter/archive.tar.gz | sed -n 's/^\(\S*\).*/sha256:\1/p'
+  args:
+    executable: /bin/bash
+  register: node_exporter_sha256
+
 - name: download node_exporter
   get_url:
     url: '{{ node_exporter_binary_url | quote }}'
     checksum: '{{ node_exporter_binary_checksum | quote }}'
     dest: /root/node_exporter/archive.tar.gz
     mode: '0700'
+  when: node_exporter_sha256.stdout != node_exporter_binary_checksum
 
 - name: unarchive node_exporter
   unarchive:
     src: /root/node_exporter/archive.tar.gz
     remote_src: yes
     dest: /root/node_exporter
+  when: node_exporter_sha256.stdout != node_exporter_binary_checksum
 
 - name: copy node_exporter binary
   shell: |
@@ -26,6 +35,7 @@
   args:
     executable: /bin/bash
   changed_when: False
+  when: node_exporter_sha256.stdout != node_exporter_binary_checksum
 
 - name: create node_exporter systemd unit
   copy:

--- a/ansible/roles/polkadot-update-binary/tasks/main.yml
+++ b/ansible/roles/polkadot-update-binary/tasks/main.yml
@@ -1,3 +1,10 @@
+- name: get currently polkadot sha256
+  shell: |
+    sha256sum /usr/local/bin/polkadot | sed -n 's/^\(\S*\).*/sha256:\1/p'
+  args:
+    executable: /bin/bash
+  register: polkadot_sha256
+
 - name: download polkadot binary
   get_url:
     url: '{{ polkadot_binary_url | quote }}'
@@ -7,12 +14,16 @@
     mode: '0700'
     owner: 'polkadot'
     group: 'polkadot'
+  when: polkadot_sha256.stdout != polkadot_binary_checksum
+
 
 - name: stop polkadot service
   systemd:
     name: polkadot.service
     state: stopped
   tags: molecule-idempotence-notest
+  when: polkadot_sha256.stdout != polkadot_binary_checksum
+
 
 - name: substitute new polkadot binary
   shell: |
@@ -26,7 +37,11 @@
   args:
     executable: /bin/bash
   changed_when: False
+  when: polkadot_sha256.stdout != polkadot_binary_checksum
+
 
 - name: restart polkadot service
   import_role:
     name: polkadot-restart-service
+  when: polkadot_sha256.stdout != polkadot_binary_checksum
+

--- a/ansible/roles/polkadot-update-binary/tasks/main.yml
+++ b/ansible/roles/polkadot-update-binary/tasks/main.yml
@@ -21,8 +21,9 @@
   systemd:
     name: polkadot.service
     state: stopped
+    daemon_reload: yes
   tags: molecule-idempotence-notest
-  when: polkadot_sha256.stdout != polkadot_binary_checksum
+  
 
 
 - name: substitute new polkadot binary
@@ -43,5 +44,3 @@
 - name: restart polkadot service
   import_role:
     name: polkadot-restart-service
-  when: polkadot_sha256.stdout != polkadot_binary_checksum
-


### PR DESCRIPTION
This PR speeds up the ansible runtime by checking the SHA256 checksum of both the polkadot binary, and the node exporter. If the correct file already exists on the node, it skips downloading and swapping it out. 