### PR TITLE
Add condition for enabling reverse proxy

### DIFF
--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -1,6 +1,5 @@
 # Specify the nodes to setup. You can add more or remove entries, as you wish.
 
-
 # ## Validator 0
 [validator_0]
 147.75.76.65
@@ -10,7 +9,7 @@ ansible_user=alice
 # Preferably use a private telemetry server
 telemetryUrl=wss://telemetry.polkadot.io/submit/
 loggingFilter='sync=warn,afg=warn,babe=warn'
-
+enableReverseProxy = false
 
 # ## Validator 1
 [validator_1]
@@ -21,13 +20,12 @@ ansible_user=bob
 # Preferably use a private telemetry server
 telemetryUrl=wss://telemetry.polkadot.io/submit/
 loggingFilter='sync=warn,afg=warn,babe=warn'
-
+enableReverseProxy = false
 
 # ## Group all nodes
 [validator:children]
 validator_0
 validator_1
-
 
 # ## Common variables
 [all:vars]

--- a/ansible/roles/polkadot-validator/tasks/firewall.yml
+++ b/ansible/roles/polkadot-validator/tasks/firewall.yml
@@ -26,14 +26,22 @@
     - node_exporter_enabled|default(false)|bool
     - not ufw_status_result.stdout is search("9616/tcp.*ALLOW IN.*Anywhere")
 
+- name: open p2p port
+  command: ufw deny {{ p2p_port }}/tcp
+  when:
+    - not enableReverseProxy|default(false)|bool
+    - not ufw_status_result.stdout is search(p2p_port ~ "/tcp.*DENY IN.*Anywhere")
+
 - name: open proxy port
   command: ufw allow {{ proxy_port }}/tcp
   when:
+    - enableReverseProxy|default(false)|bool
     - not ufw_status_result.stdout is search(proxy_port ~ "/tcp.*ALLOW IN.*Anywhere")
 
 - name: close p2p port
   command: ufw deny {{ p2p_port }}/tcp
   when:
+    - enableReverseProxy|default(false)|bool
     - not ufw_status_result.stdout is search(p2p_port ~ "/tcp.*DENY IN.*Anywhere")
 
 - name: enable firewall

--- a/ansible/roles/polkadot-validator/tasks/firewall.yml
+++ b/ansible/roles/polkadot-validator/tasks/firewall.yml
@@ -48,7 +48,7 @@
   command: ufw deny {{ proxy_port }}/tcp
   when:
     - not enableReverseProxy|default(false)|bool
-    - not ufw_status_result.stdout is search(p2p_port ~ "/tcp.*DENY IN.*Anywhere")
+    - not ufw_status_result.stdout is search(proxy_port ~ "/tcp.*DENY IN.*Anywhere")
 
 - name: enable firewall
   shell: |

--- a/ansible/roles/polkadot-validator/tasks/firewall.yml
+++ b/ansible/roles/polkadot-validator/tasks/firewall.yml
@@ -30,6 +30,7 @@
   command: ufw allow {{ p2p_port }}/tcp
   when:
     - not enableReverseProxy|default(false)|bool
+    - not ufw_status_result.stdout is search(p2p_port ~ "/tcp.*ALLOW IN.*Anywhere")
 
 - name: close p2p port
   command: ufw deny {{ p2p_port }}/tcp
@@ -42,12 +43,6 @@
   when:
     - enableReverseProxy|default(false)|bool
     - not ufw_status_result.stdout is search(proxy_port ~ "/tcp.*ALLOW IN.*Anywhere")
-
-- name: close proxy port
-  command: ufw deny {{ proxy_port }}/tcp
-  when:
-    - not enableReverseProxy|default(false)|bool
-    - not ufw_status_result.stdout is search(proxy_port ~ "/tcp.*DENY IN.*Anywhere")
 
 - name: enable firewall
   shell: |

--- a/ansible/roles/polkadot-validator/tasks/firewall.yml
+++ b/ansible/roles/polkadot-validator/tasks/firewall.yml
@@ -27,9 +27,15 @@
     - not ufw_status_result.stdout is search("9616/tcp.*ALLOW IN.*Anywhere")
 
 - name: open p2p port
-  command: ufw deny {{ p2p_port }}/tcp
+  command: ufw allow {{ p2p_port }}/tcp
   when:
     - not enableReverseProxy|default(false)|bool
+    - not ufw_status_result.stdout is search(p2p_port ~ "/tcp.*DENY IN.*Anywhere")
+
+- name: close p2p port
+  command: ufw deny {{ p2p_port }}/tcp
+  when:
+    - enableReverseProxy|default(false)|bool
     - not ufw_status_result.stdout is search(p2p_port ~ "/tcp.*DENY IN.*Anywhere")
 
 - name: open proxy port
@@ -38,10 +44,10 @@
     - enableReverseProxy|default(false)|bool
     - not ufw_status_result.stdout is search(proxy_port ~ "/tcp.*ALLOW IN.*Anywhere")
 
-- name: close p2p port
-  command: ufw deny {{ p2p_port }}/tcp
+- name: close proxy port
+  command: ufw deny {{ proxy_port }}/tcp
   when:
-    - enableReverseProxy|default(false)|bool
+    - not enableReverseProxy|default(false)|bool
     - not ufw_status_result.stdout is search(p2p_port ~ "/tcp.*DENY IN.*Anywhere")
 
 - name: enable firewall

--- a/ansible/roles/polkadot-validator/tasks/firewall.yml
+++ b/ansible/roles/polkadot-validator/tasks/firewall.yml
@@ -30,7 +30,6 @@
   command: ufw allow {{ p2p_port }}/tcp
   when:
     - not enableReverseProxy|default(false)|bool
-    - not ufw_status_result.stdout is search(p2p_port ~ "/tcp.*DENY IN.*Anywhere")
 
 - name: close p2p port
   command: ufw deny {{ p2p_port }}/tcp

--- a/ansible/roles/polkadot-validator/tasks/main.yml
+++ b/ansible/roles/polkadot-validator/tasks/main.yml
@@ -11,8 +11,6 @@
 
 - name: proxy setup
   import_tasks: proxy.yml
-  when:
-    - enableReverseProxy|default(false)|bool
 
 - name: service setup
   import_tasks: service.yml

--- a/ansible/roles/polkadot-validator/tasks/main.yml
+++ b/ansible/roles/polkadot-validator/tasks/main.yml
@@ -11,6 +11,8 @@
 
 - name: proxy setup
   import_tasks: proxy.yml
+  when:
+    - enableReverseProxy|default(false)|bool
 
 - name: service setup
   import_tasks: service.yml

--- a/ansible/roles/polkadot-validator/tasks/proxy.yml
+++ b/ansible/roles/polkadot-validator/tasks/proxy.yml
@@ -25,6 +25,8 @@
     src: proxy.conf.j2
     dest: /etc/nginx/streams-enabled/polkadot-proxy.conf
     mode: 0600
+  when:
+    - enableReverseProxy|default(false)|bool
 
 - name: restart nginx service
   systemd:

--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -11,7 +11,9 @@ ExecStart=/usr/local/bin/polkadot \
   --name {{ project|default('project') }}-sv-validator-{{ groups['validator'].index(inventory_hostname) }} \
   {% endif %}
   --validator \
+  {% if hostvars[inventory_hostname].enableReverseProxy is defined and hostvars[inventory_hostname].enableReverseProxy is true %}
   --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
+  {% endif %}
   --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
   --rpc-methods=Unsafe \
   {% if hostvars[inventory_hostname].polkadot_additional_common_flags is defined and hostvars[inventory_hostname].polkadot_additional_common_flags|length %}

--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -11,7 +11,7 @@ ExecStart=/usr/local/bin/polkadot \
   --name {{ project|default('project') }}-sv-validator-{{ groups['validator'].index(inventory_hostname) }} \
   {% endif %}
   --validator \
-  {% if hostvars[inventory_hostname].enableReverseProxy is defined and hostvars[inventory_hostname].enableReverseProxy is true %}
+  {% if hostvars[inventory_hostname].enableReverseProxy is defined and hostvars[inventory_hostname].enableReverseProxy %}
   --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
   {% endif %}
   --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \


### PR DESCRIPTION
Allows you to enable/disable the  reverse proxy via the inventory (**disabled by default**):

```yaml
# ## Validator 0
[validator_0]
147.75.76.65

[validator_0:vars]
ansible_user=alice
# Preferably use a private telemetry server
telemetryUrl=wss://telemetry.polkadot.io/submit/
loggingFilter='sync=warn,afg=warn,babe=warn'
enableReverseProxy = false
```

**NOTE**: I don't want to just make assumptions about user's systems. So when you execute this script and do not enable the reverse proxy, it will:
* Not stop/disable/uninstall nginx.
* Not close the proxy port (80) via firewall.

Is this behavior acceptable?