### PR TITLE
Use TCP nodelay for the nginx proxy

### DIFF
--- a/ansible/roles/polkadot-validator/templates/proxy.conf.j2
+++ b/ansible/roles/polkadot-validator/templates/proxy.conf.j2
@@ -1,4 +1,5 @@
 server {
   listen 0.0.0.0:{{ proxy_port }};
   proxy_pass localhost:{{ p2p_port }};
+  tcp_nodelay on;
 }


### PR DESCRIPTION
I'm making this change blindly by copy-pasting from the official documentation, so I'm not actually 100% sure that the syntax is correct.