### PR TITLE
[WIP] Cleanup j2 templating, expand sample inventory with additional parameters

### DIFF
--- a/GUIDE_ANSIBLE.md
+++ b/GUIDE_ANSIBLE.md
@@ -71,16 +71,16 @@ Example:
 
 [validator_0:vars]
 ansible_user=alice
-telemetryUrl=wss://telemetry.polkadot.io/submit/
-loggingFilter='sync=trace,afg=trace,babe=debug'
+telemetry_url=wss://telemetry.polkadot.io/submit/
+logging_filter='sync=trace,afg=trace,babe=debug'
 
 [validator_1]
 162.12.35.55
 
 [validator_1:vars]
 ansible_user=bob
-telemetryUrl=wss://telemetry.polkadot.io/submit/
-loggingFilter='sync=trace,afg=trace,babe=debug'
+telemetry_url=wss://telemetry.polkadot.io/submit/
+logging_filter='sync=trace,afg=trace,babe=debug'
 ```
 
 ### Grouping Validators

--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -10,7 +10,7 @@ ansible_user=alice
 nodeName='Alice Validator'
 # Setup telemetry endpoint (optional)
 telemetryUrl=wss://telemetry.polkadot.io/submit/
-# Only log warnings (optional)
+# Only log specify levels, e.g. warnings (optional)
 loggingFilter='sync=warn,afg=warn,babe=warn'
 # Location for database, keys, etc (optional)
 basePath='/mnt/volume'

--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -4,20 +4,21 @@
 [validator_0]
 147.75.76.65
 
+# NOTE: optional variables can just be removed.
 [validator_0:vars]
 ansible_user=alice
 # Set an individual node name (optional)
-nodeName='Alice Validator'
+node_name='Alice Validator'
 # Setup telemetry endpoint (optional)
-telemetryUrl=wss://telemetry.polkadot.io/submit/
+telemetry_url=wss://telemetry.polkadot.io/submit/
 # Only log specify levels, e.g. warnings (optional)
-loggingFilter='sync=warn,afg=warn,babe=warn'
+logging_filter='sync=warn,afg=warn,babe=warn'
 # Location for database, keys, etc (optional)
-basePath='/mnt/volume'
+base_path='/mnt/volume'
 # Setup a nginx reverse proxy in front of the binary (optional). Disabled by default.
-enableReverseProxy = false
+enable_reverse_proxy = false
 # Any additional flags passed on to the 'polkadot' binary (optional)
-additionalFlags = '--no-prometheus --no-mdns'
+additional_flags = '--no-prometheus --no-mdns'
 
 # Validator 1
 [validator_1]
@@ -25,8 +26,8 @@ additionalFlags = '--no-prometheus --no-mdns'
 
 [validator_1:vars]
 ansible_user=bob
-telemetryUrl=wss://telemetry.polkadot.io/submit/
-loggingFilter='sync=warn,afg=warn,babe=warn'
+telemetry_url=wss://telemetry.polkadot.io/submit/
+logging_filter='sync=warn,afg=warn,babe=warn'
 
 # ## Group all nodes
 [validator:children]

--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -1,35 +1,40 @@
 # Specify the nodes to setup. You can add more or remove entries, as you wish.
 
-# ## Validator 0
+# Validator 0
 [validator_0]
 147.75.76.65
 
 [validator_0:vars]
 ansible_user=alice
-# Preferably use a private telemetry server
-telemetryUrl=wss://telemetry.polkadot.io/submit/
-loggingFilter='sync=warn,afg=warn,babe=warn'
-enableReverseProxy = false
+#nodeName='Alice Validator'
+#telemetryUrl=wss://telemetry.polkadot.io/submit/
+## Only log warnings:
+#loggingFilter='sync=warn,afg=warn,babe=warn'
+## Location for database, keys, etc:
+#basePath='/mnt/volume'
+## Setup a nginx reverse proxy in front of the binary:
+#enableReverseProxy = false
+## Any additional flags passed on to the 'polkadot' binary:
+#additionalFlags = '--unsafe-pruning --no-mdns'
 
-# ## Validator 1
+# Validator 1
 [validator_1]
 162.12.35.55
 
 [validator_1:vars]
 ansible_user=bob
-# Preferably use a private telemetry server
 telemetryUrl=wss://telemetry.polkadot.io/submit/
 loggingFilter='sync=warn,afg=warn,babe=warn'
-enableReverseProxy = false
 
 # ## Group all nodes
 [validator:children]
 validator_0
 validator_1
 
-# ## Common variables
+# Common variables
 [all:vars]
-# The name for how each node should be prefixed for the telemetry name
+# Project name. Will be used as a prefix for the auto-generated node names
+# if an individual `nodeName` is not specified.
 project=alice-in-wonderland
 
 # Can be left as is.
@@ -56,7 +61,7 @@ polkadot_binary_checksum='sha256:00185307376ca0bacf28504e76d4c61ebf84abfba6c3178
 polkadot_network_id=polkadot
 chain=polkadot
 
-# Nginx authentication settings.
+# Nginx authentication settings (for Prometheus).
 nginx_user='prometheus'
 nginx_password='nginx_password'
 

--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -6,16 +6,18 @@
 
 [validator_0:vars]
 ansible_user=alice
-#nodeName='Alice Validator'
-#telemetryUrl=wss://telemetry.polkadot.io/submit/
-## Only log warnings:
-#loggingFilter='sync=warn,afg=warn,babe=warn'
-## Location for database, keys, etc:
-#basePath='/mnt/volume'
-## Setup a nginx reverse proxy in front of the binary:
-#enableReverseProxy = false
-## Any additional flags passed on to the 'polkadot' binary:
-#additionalFlags = '--unsafe-pruning --no-mdns'
+# Set an individual node name (optional)
+nodeName='Alice Validator'
+# Setup telemetry endpoint (optional)
+telemetryUrl=wss://telemetry.polkadot.io/submit/
+# Only log warnings (optional)
+loggingFilter='sync=warn,afg=warn,babe=warn'
+# Location for database, keys, etc (optional)
+basePath='/mnt/volume'
+# Setup a nginx reverse proxy in front of the binary (optional)
+enableReverseProxy = false
+# Any additional flags passed on to the 'polkadot' binary (optional)
+additionalFlags = '--unsafe-pruning --no-mdns'
 
 # Validator 1
 [validator_1]

--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -14,7 +14,7 @@ telemetryUrl=wss://telemetry.polkadot.io/submit/
 loggingFilter='sync=warn,afg=warn,babe=warn'
 # Location for database, keys, etc (optional)
 basePath='/mnt/volume'
-# Setup a nginx reverse proxy in front of the binary (optional)
+# Setup a nginx reverse proxy in front of the binary (optional). Disabled by default.
 enableReverseProxy = false
 # Any additional flags passed on to the 'polkadot' binary (optional)
 additionalFlags = '--unsafe-pruning --no-mdns'

--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -17,7 +17,7 @@ basePath='/mnt/volume'
 # Setup a nginx reverse proxy in front of the binary (optional). Disabled by default.
 enableReverseProxy = false
 # Any additional flags passed on to the 'polkadot' binary (optional)
-additionalFlags = '--unsafe-pruning --no-mdns'
+additionalFlags = '--no-prometheus --no-mdns'
 
 # Validator 1
 [validator_1]

--- a/ansible/roles/polkadot-validator/tasks/service.yml
+++ b/ansible/roles/polkadot-validator/tasks/service.yml
@@ -14,6 +14,8 @@
   uri:
     url: https://api.ipify.org?format=json
   register: public_ip
+  when:
+    - enableReverseProxy|default(false)|bool
 
 - name: create polkadot service file
   template:

--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -5,42 +5,94 @@ Description=Polkadot Node
 User=polkadot
 Group=polkadot
 ExecStart=/usr/local/bin/polkadot \
+  --validator \
+  --chain={{ chain }} \
+  --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
+  --rpc-methods=Unsafe \
+  {#
+  ## NODE NAME
+  #}
   {% if hostvars[inventory_hostname].nodeName is defined and hostvars[inventory_hostname].nodeName|length %}
   --name {{ hostvars[inventory_hostname].nodeName }} \
   {% else %}
   --name {{ project|default('project') }}-sv-validator-{{ groups['validator'].index(inventory_hostname) }} \
   {% endif %}
-  --validator \
-  {% if hostvars[inventory_hostname].enableReverseProxy is defined and hostvars[inventory_hostname].enableReverseProxy %}
-  --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
-  {% endif %}
-  --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
-  --rpc-methods=Unsafe \
-  {% if hostvars[inventory_hostname].polkadot_additional_common_flags is defined and hostvars[inventory_hostname].polkadot_additional_common_flags|length %}
-  {{ hostvars[inventory_hostname].polkadot_additional_common_flags }} \
-  {% endif %}
-  {% if hostvars[inventory_hostname].polkadot_additional_validator_flags is defined and hostvars[inventory_hostname].polkadot_additional_validator_flags|length %}
-  {{ hostvars[inventory_hostname].polkadot_additional_validator_flags }} \
-  {% endif %}
-  {% if hostvars[inventory_hostname].loggingFilter is defined and hostvars[inventory_hostname].loggingFilter|length %}
-  -l{{ hostvars[inventory_hostname].loggingFilter }} \
-  {% endif %}
-  --chain={{ chain }} \
-  {% if hostvars[inventory_hostname].base_path is defined and hostvars[inventory_hostname].base_path|length %}
-  --base-path '{{ hostvars[inventory_hostname].base_path }}' \
-  {% endif %}
+  {#
+  ## (RUNTIME) EXECUTION
+  #}
   {% if hostvars[inventory_hostname].execution is defined and hostvars[inventory_hostname].execution|length %}
   --execution {{ hostvars[inventory_hostname].execution }} \
   {% endif %}
+  {#
+  ## WASM EXECUTION
+  #}
+  {% if hostvars[inventory_hostname].wasmExecution is defined and hostvars[inventory_hostname].wasmExecution|length %}
+  --wasm-execution {{ hostvars[inventory_hostname].wasmExecution }} \
+  {% else %}
+  --wasm-execution Compiled \
+  {% endif %}
+  {#
+  ## TELEMETRY
+  #}
+  {% if hostvars[inventory_hostname].telemetryUrl is defined and hostvars[inventory_hostname].telemetryUrl|length %}
+  --telemetry-url '{{ hostvars[inventory_hostname].telemetryUrl }} 1'
+  {% else %}
+  --no-telemetry
+  {% endif %}
+  {#
+  ## REVERSE PROXY
+  #}
+  {% if hostvars[inventory_hostname].enableReverseProxy is defined and hostvars[inventory_hostname].enableReverseProxy %}
+  --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
+  {% endif %}
+  {#
+  ## LOGGING FILTER
+  #}
+  {% if hostvars[inventory_hostname].loggingFilter is defined and hostvars[inventory_hostname].loggingFilter|length %}
+  -l{{ hostvars[inventory_hostname].loggingFilter }} \
+  {% endif %}
+  {#
+  ## BASE/DB PATH
+  #}
+  {% if hostvars[inventory_hostname].basePath is defined and hostvars[inventory_hostname].basePath|length %}
+  --base-path '{{ hostvars[inventory_hostname].basePath }}' \
+  {% endif %}
+  {#
+  ## ADDITIONAL FLAGS
+  #}
+  {% if hostvars[inventory_hostname].additionalFlags is defined and hostvars[inventory_hostname].additionalFlags|length %}
+  {{ hostvars[inventory_hostname].additionalFlags }} \
+  {% endif %}
+  {#
+  #
+  # --- DEPRECATED flags after this line. Used for backwards compatibility ---
+  #
+  #}
+  {#
+  ## WASM EXECUTION
+  #}
   {% if hostvars[inventory_hostname].wasm_execution is defined and hostvars[inventory_hostname].wasm_execution|length %}
   --wasm-execution {{ hostvars[inventory_hostname].wasm_execution }} \
   {% else %}
   --wasm-execution Compiled \
   {% endif %}
-  {% if hostvars[inventory_hostname].telemetryUrl is defined and hostvars[inventory_hostname].telemetryUrl|length %}
-  --telemetry-url '{{ hostvars[inventory_hostname].telemetryUrl }} 1'
-  {% else %}
-  --no-telemetry
+  {#
+  ## BASE/DB PATH
+  #}
+  {% if hostvars[inventory_hostname].base_path is defined and hostvars[inventory_hostname].base_path|length %}
+  --base-path '{{ hostvars[inventory_hostname].base_path }}' \
+  {% endif %}
+  {#
+  ## ADDITIONAL COMMON FLAGS
+  #}
+  {% if hostvars[inventory_hostname].polkadot_additional_common_flags is defined and hostvars[inventory_hostname].polkadot_additional_common_flags|length %}
+  {{ hostvars[inventory_hostname].polkadot_additional_common_flags }} \
+  {% endif %}
+  {#
+  ## ADDITIONAL FLAGS
+  #}
+  {% if hostvars[inventory_hostname].polkadot_additional_validator_flags is defined and hostvars[inventory_hostname].polkadot_additional_validator_flags|length %}
+  {{ hostvars[inventory_hostname].polkadot_additional_validator_flags }} \
   {% endif %}
 
 Restart=always

--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -8,10 +8,10 @@
 {% set basePath = hostvars[inventory_hostname].basePath|default(None) %}
 {% set additionalFlags = hostvars[inventory_hostname].additionalFlags|default(None) %}
 {# ## Legacy/deprecated flags #}
-{% if wasmExecution is undefined %}
+{% if wasmExecution is none %}
   {% set wasmExecution = hostvars[inventory_hostname].wasm_execution|default(None) %}
 {% endif %}
-{% if basePath is undefined %}
+{% if basePath is none %}
   {% set basePath = hostvars[inventory_hostname].base_path|default(None) %}
 {% endif %}
 {% set additionalCommonFlags = hostvars[inventory_hostname].polkadot_additional_common_flags|default(None) %}
@@ -24,46 +24,48 @@ Description=Polkadot Node
 User=polkadot
 Group=polkadot
 ExecStart=/usr/local/bin/polkadot \
-  --validator \
-  --chain={{ chain }} \
-  --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
-  --rpc-methods=Unsafe \
+  {% if execution is not none and execution|length %}
   --execution {{ execution }} \
-  {% if nodeName is defined and nodeName|length %}
-  {{ nodeName }} \
-  {% else %}
-  {{ project|default('project') }}-sv-validator-{{ groups['validator'].index(inventory_hostname) }} \
   {% endif %}
-  {% if wasmExecution is defined and wasmExecution|length %}
+  {% if nodeName is not none and nodeName|length %}
+  --name {{ nodeName }} \
+  {% else %}
+  --name {{ project|default('project') }}-sv-validator-{{ groups['validator'].index(inventory_hostname) }} \
+  {% endif %}
+  {% if wasmExecution is not none and wasmExecution|length %}
   --wasm-execution {{ wasmExecution }} \
   {% else %}
   --wasm-execution Compiled \
   {% endif %}
-  {% if telemetryUrl is defined and telemetryUrl|length %}
+  {% if telemetryUrl is not none and telemetryUrl|length %}
   --telemetry-url '{{ telemetryUrl }} 1' \
   {% else %}
   --no-telemetry \
   {% endif %}
-  {% if enableReverseProxy is defined and enableReverseProxy %}
+  {% if enableReverseProxy is not none and enableReverseProxy %}
   --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
   {% endif %}
-  {% if loggingFilter is defined and loggingFilter|length %}
+  {% if loggingFilter is not none and loggingFilter|length %}
   -l{{ loggingFilter }} \
   {% endif %}
-  {% if basePath is defined and basePath|length %}
+  {% if basePath is not none and basePath|length %}
   --base-path '{{ basePath }}' \
   {% endif %}
-  {% if additionalFlags is defined and additionalFlags|length %}
+  {% if additionalFlags is not none and additionalFlags|length %}
   {{ additionalFlags }} \
   {% endif %}
   {# --- DEPRECATED --- #}
-  {% if additionalCommonFlags is defined and additionalCommonFlags|length %}
+  {% if additionalCommonFlags is not none and additionalCommonFlags|length %}
   {{ additionalCommonFlags }} \
   {% endif %}
-  {% if additionalValidatorFlags is defined and additionalValidatorFlags|length %}
+  {% if additionalValidatorFlags is not none and additionalValidatorFlags|length %}
   {{ additionalValidatorFlags }} \
   {% endif %}
   {# --- #}
+  --validator \
+  --chain={{ chain }} \
+  --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
+  --rpc-methods=Unsafe
 
 Restart=always
 RestartSec=60

--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -1,3 +1,18 @@
+{# --- PREPARE VARIABLES #}
+{% set nodeName = hostvars[inventory_hostname].nodeName|default(project|default('project')+'-sv-validator-'+groups['validator'].index(inventory_hostname)) %}
+{% set execution = hostvars[inventory_hostname].execution|default(None) %}
+{% set wasmExecution = hostvars[inventory_hostname].wasmExecution|default('Compiled') %}
+{% set telemetryUrl = hostvars[inventory_hostname].telemetryUrl|default(None) %}
+{% set enableReverseProxy = hostvars[inventory_hostname].enableReverseProxy|default(false) %}
+{% set loggingFilter = hostvars[inventory_hostname].loggingFilter|default(None) %}
+{% set basePath = hostvars[inventory_hostname].basePath|default(None) %}
+{% set additionalFlags = hostvars[inventory_hostname].additionalFlags|default(None) %}
+{# ## Legacy/deprecated flags #}
+{% set wasmExecution = hostvars[inventory_hostname].wasm_execution|default('Compiled') %}
+{% set basePath = hostvars[inventory_hostname].base_path|default(None) %}
+{% set polkadotAdditionalCommonFlags = hostvars[inventory_hostname].polkadot_additional_common_flags|default(None) %}
+{% set polkadotAdditionalValidatorFlags = hostvars[inventory_hostname].polkadot_additional_validator_flags|default(None) %}
+{# --- #}
 [Unit]
 Description=Polkadot Node
 
@@ -9,91 +24,34 @@ ExecStart=/usr/local/bin/polkadot \
   --chain={{ chain }} \
   --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
   --rpc-methods=Unsafe \
-  {#
-  ## NODE NAME
-  #}
-  {% if hostvars[inventory_hostname].nodeName is defined and hostvars[inventory_hostname].nodeName|length %}
-  --name {{ hostvars[inventory_hostname].nodeName }} \
+  --name {{ nodeName }} \
+  --execution {{ execution }} \
+  --wasm-execution {{ wasmExecution }} \
+  {% if telemetryUrl is defined %}
+  --telemetry-url '{{ telemetryUrl }} 1' \
   {% else %}
-  --name {{ project|default('project') }}-sv-validator-{{ groups['validator'].index(inventory_hostname) }} \
+  --no-telemetry \
   {% endif %}
-  {#
-  ## (RUNTIME) EXECUTION
-  #}
-  {% if hostvars[inventory_hostname].execution is defined and hostvars[inventory_hostname].execution|length %}
-  --execution {{ hostvars[inventory_hostname].execution }} \
-  {% endif %}
-  {#
-  ## WASM EXECUTION
-  #}
-  {% if hostvars[inventory_hostname].wasmExecution is defined and hostvars[inventory_hostname].wasmExecution|length %}
-  --wasm-execution {{ hostvars[inventory_hostname].wasmExecution }} \
-  {% else %}
-  --wasm-execution Compiled \
-  {% endif %}
-  {#
-  ## TELEMETRY
-  #}
-  {% if hostvars[inventory_hostname].telemetryUrl is defined and hostvars[inventory_hostname].telemetryUrl|length %}
-  --telemetry-url '{{ hostvars[inventory_hostname].telemetryUrl }} 1'
-  {% else %}
-  --no-telemetry
-  {% endif %}
-  {#
-  ## REVERSE PROXY
-  #}
-  {% if hostvars[inventory_hostname].enableReverseProxy is defined and hostvars[inventory_hostname].enableReverseProxy %}
+  {% if enableReverseProxy %}
   --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
   {% endif %}
-  {#
-  ## LOGGING FILTER
-  #}
-  {% if hostvars[inventory_hostname].loggingFilter is defined and hostvars[inventory_hostname].loggingFilter|length %}
-  -l{{ hostvars[inventory_hostname].loggingFilter }} \
+  {% if loggingFilter is defined %}
+  -l{{ loggingFilter }} \
   {% endif %}
-  {#
-  ## BASE/DB PATH
-  #}
-  {% if hostvars[inventory_hostname].basePath is defined and hostvars[inventory_hostname].basePath|length %}
-  --base-path '{{ hostvars[inventory_hostname].basePath }}' \
+  {% if basePath is defined %}
+  --base-path '{{ basePath }}' \
   {% endif %}
-  {#
-  ## ADDITIONAL FLAGS
-  #}
-  {% if hostvars[inventory_hostname].additionalFlags is defined and hostvars[inventory_hostname].additionalFlags|length %}
-  {{ hostvars[inventory_hostname].additionalFlags }} \
+  {% if additionalFlags is defined %}
+  {{ additionalFlags }} \
   {% endif %}
-  {#
-  #
-  # --- DEPRECATED flags after this line. Used for backwards compatibility ---
-  #
-  #}
-  {#
-  ## WASM EXECUTION
-  #}
-  {% if hostvars[inventory_hostname].wasm_execution is defined and hostvars[inventory_hostname].wasm_execution|length %}
-  --wasm-execution {{ hostvars[inventory_hostname].wasm_execution }} \
-  {% else %}
-  --wasm-execution Compiled \
+  {# --- DEPRECATED --- #}
+  {% if polkadotAdditionalCommonFlags is defined %}
+  {{ polkadotAdditionalCommonFlags }} \
   {% endif %}
-  {#
-  ## BASE/DB PATH
-  #}
-  {% if hostvars[inventory_hostname].base_path is defined and hostvars[inventory_hostname].base_path|length %}
-  --base-path '{{ hostvars[inventory_hostname].base_path }}' \
+  {% if polkadotAdditionalValidatorFlags is defined %}
+  {{ polkadotAdditionalValidatorFlags }} \
   {% endif %}
-  {#
-  ## ADDITIONAL COMMON FLAGS
-  #}
-  {% if hostvars[inventory_hostname].polkadot_additional_common_flags is defined and hostvars[inventory_hostname].polkadot_additional_common_flags|length %}
-  {{ hostvars[inventory_hostname].polkadot_additional_common_flags }} \
-  {% endif %}
-  {#
-  ## ADDITIONAL FLAGS
-  #}
-  {% if hostvars[inventory_hostname].polkadot_additional_validator_flags is defined and hostvars[inventory_hostname].polkadot_additional_validator_flags|length %}
-  {{ hostvars[inventory_hostname].polkadot_additional_validator_flags }} \
-  {% endif %}
+  {# --- #}
 
 Restart=always
 RestartSec=60

--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -1,17 +1,21 @@
 {# --- PREPARE VARIABLES #}
-{% set nodeName = hostvars[inventory_hostname].nodeName|default(project|default('project')+'-sv-validator-'+groups['validator'].index(inventory_hostname)) %}
+{% set nodeName = hostvars[inventory_hostname].nodeName|default(None) %}
 {% set execution = hostvars[inventory_hostname].execution|default(None) %}
-{% set wasmExecution = hostvars[inventory_hostname].wasmExecution|default('Compiled') %}
+{% set wasmExecution = hostvars[inventory_hostname].wasmExecution|default(None) %}
 {% set telemetryUrl = hostvars[inventory_hostname].telemetryUrl|default(None) %}
-{% set enableReverseProxy = hostvars[inventory_hostname].enableReverseProxy|default(false) %}
+{% set enableReverseProxy = hostvars[inventory_hostname].enableReverseProxy|default(None) %}
 {% set loggingFilter = hostvars[inventory_hostname].loggingFilter|default(None) %}
 {% set basePath = hostvars[inventory_hostname].basePath|default(None) %}
 {% set additionalFlags = hostvars[inventory_hostname].additionalFlags|default(None) %}
 {# ## Legacy/deprecated flags #}
-{% set wasmExecution = hostvars[inventory_hostname].wasm_execution|default('Compiled') %}
-{% set basePath = hostvars[inventory_hostname].base_path|default(None) %}
-{% set polkadotAdditionalCommonFlags = hostvars[inventory_hostname].polkadot_additional_common_flags|default(None) %}
-{% set polkadotAdditionalValidatorFlags = hostvars[inventory_hostname].polkadot_additional_validator_flags|default(None) %}
+{% if wasmExecution is undefined %}
+  {% set wasmExecution = hostvars[inventory_hostname].wasm_execution|default(None) %}
+{% endif %}
+{% if basePath is undefined %}
+  {% set basePath = hostvars[inventory_hostname].base_path|default(None) %}
+{% endif %}
+{% set additionalCommonFlags = hostvars[inventory_hostname].polkadot_additional_common_flags|default(None) %}
+{% set additionalValidatorFlags = hostvars[inventory_hostname].polkadot_additional_validator_flags|default(None) %}
 {# --- #}
 [Unit]
 Description=Polkadot Node
@@ -24,32 +28,40 @@ ExecStart=/usr/local/bin/polkadot \
   --chain={{ chain }} \
   --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
   --rpc-methods=Unsafe \
-  --name {{ nodeName }} \
   --execution {{ execution }} \
+  {% if nodeName is defined and nodeName|length %}
+  {{ nodeName }} \
+  {% else %}
+  {{ project|default('project') }}-sv-validator-{{ groups['validator'].index(inventory_hostname) }} \
+  {% endif %}
+  {% if wasmExecution is defined and wasmExecution|length %}
   --wasm-execution {{ wasmExecution }} \
-  {% if telemetryUrl is defined %}
+  {% else %}
+  --wasm-execution Compiled \
+  {% endif %}
+  {% if telemetryUrl is defined and telemetryUrl|length %}
   --telemetry-url '{{ telemetryUrl }} 1' \
   {% else %}
   --no-telemetry \
   {% endif %}
-  {% if enableReverseProxy %}
+  {% if enableReverseProxy is defined and enableReverseProxy %}
   --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
   {% endif %}
-  {% if loggingFilter is defined %}
+  {% if loggingFilter is defined and loggingFilter|length %}
   -l{{ loggingFilter }} \
   {% endif %}
-  {% if basePath is defined %}
+  {% if basePath is defined and basePath|length %}
   --base-path '{{ basePath }}' \
   {% endif %}
-  {% if additionalFlags is defined %}
+  {% if additionalFlags is defined and additionalFlags|length %}
   {{ additionalFlags }} \
   {% endif %}
   {# --- DEPRECATED --- #}
-  {% if polkadotAdditionalCommonFlags is defined %}
-  {{ polkadotAdditionalCommonFlags }} \
+  {% if additionalCommonFlags is defined and additionalCommonFlags|length %}
+  {{ additionalCommonFlags }} \
   {% endif %}
-  {% if polkadotAdditionalValidatorFlags is defined %}
-  {{ polkadotAdditionalValidatorFlags }} \
+  {% if additionalValidatorFlags is defined and additionalValidatorFlags|length %}
+  {{ additionalValidatorFlags }} \
   {% endif %}
   {# --- #}
 

--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -1,18 +1,24 @@
 {# --- PREPARE VARIABLES #}
-{% set nodeName = hostvars[inventory_hostname].nodeName|default(None) %}
+{% set node_name = hostvars[inventory_hostname].node_name|default(None) %}
 {% set execution = hostvars[inventory_hostname].execution|default(None) %}
-{% set wasmExecution = hostvars[inventory_hostname].wasmExecution|default(None) %}
-{% set telemetryUrl = hostvars[inventory_hostname].telemetryUrl|default(None) %}
-{% set enableReverseProxy = hostvars[inventory_hostname].enableReverseProxy|default(None) %}
-{% set loggingFilter = hostvars[inventory_hostname].loggingFilter|default(None) %}
-{% set basePath = hostvars[inventory_hostname].basePath|default(None) %}
-{% set additionalFlags = hostvars[inventory_hostname].additionalFlags|default(None) %}
+{% set wasm_execution = hostvars[inventory_hostname].wasm_execution|default(None) %}
+{% set telemetry_url = hostvars[inventory_hostname].telemetry_url|default(None) %}
+{% set enable_reverse_proxy = hostvars[inventory_hostname].enable_reverse_proxy|default(None) %}
+{% set logging_filter = hostvars[inventory_hostname].logging_filter|default(None) %}
+{% set base_path = hostvars[inventory_hostname].base_path|default(None) %}
+{% set additional_flags = hostvars[inventory_hostname].additional_flags|default(None) %}
 {# ## Legacy/deprecated flags #}
-{% if wasmExecution is none %}
-  {% set wasmExecution = hostvars[inventory_hostname].wasm_execution|default(None) %}
+{% if node_name is none %}
+  {% set node_name = hostvars[inventory_hostname].nodeName|default(None) %}
 {% endif %}
-{% if basePath is none %}
-  {% set basePath = hostvars[inventory_hostname].base_path|default(None) %}
+{% if telemetry_url is none %}
+  {% set telemetry_url = hostvars[inventory_hostname].telemetryUrl|default(None) %}
+{% endif %}
+{% if enable_reverse_proxy is none %}
+  {% set enable_reverse_proxy = hostvars[inventory_hostname].enableReverseProxy|default(None) %}
+{% endif %}
+{% if logging_filter is none %}
+  {% set logging_filter = hostvars[inventory_hostname].loggingFilter|default(None) %}
 {% endif %}
 {% set additionalCommonFlags = hostvars[inventory_hostname].polkadot_additional_common_flags|default(None) %}
 {% set additionalValidatorFlags = hostvars[inventory_hostname].polkadot_additional_validator_flags|default(None) %}
@@ -27,32 +33,32 @@ ExecStart=/usr/local/bin/polkadot \
   {% if execution is not none and execution|length %}
   --execution {{ execution }} \
   {% endif %}
-  {% if nodeName is not none and nodeName|length %}
-  --name {{ nodeName }} \
+  {% if node_name is not none and node_name|length %}
+  --name {{ node_name }} \
   {% else %}
   --name {{ project|default('project') }}-sv-validator-{{ groups['validator'].index(inventory_hostname) }} \
   {% endif %}
-  {% if wasmExecution is not none and wasmExecution|length %}
-  --wasm-execution {{ wasmExecution }} \
+  {% if wasm_execution is not none and wasm_execution|length %}
+  --wasm-execution {{ wasm_execution }} \
   {% else %}
   --wasm-execution Compiled \
   {% endif %}
-  {% if telemetryUrl is not none and telemetryUrl|length %}
-  --telemetry-url '{{ telemetryUrl }} 1' \
+  {% if telemetry_url is not none and telemetry_url|length %}
+  --telemetry-url '{{ telemetry_url }} 1' \
   {% else %}
   --no-telemetry \
   {% endif %}
-  {% if enableReverseProxy is not none and enableReverseProxy %}
+  {% if enable_reverse_proxy is not none and enable_reverse_proxy %}
   --public-addr=/ip4/{{ hostvars[inventory_hostname].public_ip.json.ip }}/tcp/{{ proxy_port }} \
   {% endif %}
-  {% if loggingFilter is not none and loggingFilter|length %}
-  -l{{ loggingFilter }} \
+  {% if logging_filter is not none and logging_filter|length %}
+  -l{{ logging_filter }} \
   {% endif %}
-  {% if basePath is not none and basePath|length %}
-  --base-path '{{ basePath }}' \
+  {% if base_path is not none and base_path|length %}
+  --base-path '{{ base_path }}' \
   {% endif %}
-  {% if additionalFlags is not none and additionalFlags|length %}
-  {{ additionalFlags }} \
+  {% if additional_flags is not none and additional_flags|length %}
+  {{ additional_flags }} \
   {% endif %}
   {# --- DEPRECATED --- #}
   {% if additionalCommonFlags is not none and additionalCommonFlags|length %}


### PR DESCRIPTION
```yaml
# Validator 0
[validator_0]
147.75.76.65

# NOTE: optional variables can just be removed.
[validator_0:vars]
ansible_user=alice
# Set an individual node name (optional)
node_name='Alice Validator'
# Setup telemetry endpoint (optional)
telemetry_url=wss://telemetry.polkadot.io/submit/
# Only log specify levels, e.g. warnings (optional)
logging_filter='sync=warn,afg=warn,babe=warn'
# Location for database, keys, etc (optional)
base_path='/mnt/volume'
# Setup a nginx reverse proxy in front of the binary (optional). Disabled by default.
enable_reverse_proxy = false
# Any additional flags passed on to the 'polkadot' binary (optional)
additional_flags = '--no-prometheus --no-mdns'
```

It's basically done, but need to discuss snake_case vs camelCase. I think for yaml camelCase is better, but we already have everything defined in snake_case which and would therefore break backwards compatibility with existing inventories. I will probably convert everything to snake_case.