### PR TITLE
rename inventory.yml to inventory.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 build/*
-ansible/inventory
+ansible/inventory.ini
 ansible/**/__pycache__
 yarn-error.log
 .env

--- a/GUIDE_ANSIBLE.md
+++ b/GUIDE_ANSIBLE.md
@@ -172,11 +172,11 @@ Once the inventory file is configured, simply run the setup script and specify
 the `sudo` password for the remote machines.
 
 **NOTE**: If no inventory path is specified, it will try to look for
-`ansible/inventory.yml` by default.
+`ansible/inventory.ini` by default.
 
 ```console
 user@pc:~/polkadot-secure-validator/ansible$ chmod +x setup.sh
-user@pc:~/polkadot-secure-validator/ansible$ ./setup.sh my_inventory.yml
+user@pc:~/polkadot-secure-validator/ansible$ ./setup.sh inventory.ini
 Sudo password for remote servers:
 >> Pulling upstream changes... [OK]
 >> Testing Ansible availability... [OK]
@@ -194,7 +194,7 @@ Alternatively, execute the Playbook manually ("become" implies `sudo`
 privileges).
 
 ```console
-user@pc:~/polkadot-secure-validator/ansible$ ansible-playbook -i my_inventory.yml main.yml --become --ask-become
+user@pc:~/polkadot-secure-validator/ansible$ ansible-playbook -i inventory.ini main.yml --become --ask-become
 ```
 
 The `setup.sh` script handles some extra functionality, such as downloading the

--- a/ansible/setup.sh
+++ b/ansible/setup.sh
@@ -11,7 +11,7 @@ function handle_error() {
 }
 
 ANSIBLE_FILES_DIR="$(dirname "$0")"
-INVENTORY="${1:-${ANSIBLE_FILES_DIR}/inventory.yml}"
+INVENTORY="${1:-${ANSIBLE_FILES_DIR}/inventory.ini}"
 
 echo -n ">> Checking inventory file (${INVENTORY}) exists and is readable... "
 [ -r "${INVENTORY}" ]; handle_error "Please check https://github.com/w3f/polkadot-secure-validator/blob/master/GUIDE_ANSIBLE.md#inventory"


### PR DESCRIPTION
use an extension that correctly reflects the file contents.

inventory is created by copying inventory.sample to a new file which is referenced elsewhere in this repo as inventory.yml or my_inventory.yml

the incorrect yaml file extension is confusing and misleading both for users and text editor syntax highlighters

this pr renames references to inventory.yml and my_inventory.yml as inventory.ini to remove this confusion