### PR TITLE
Add on-failure configuration to the systemd

### DIFF
--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -25,6 +25,8 @@
 {# --- #}
 [Unit]
 Description=Polkadot Node
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 User=polkadot
@@ -76,8 +78,8 @@ ExecStart=/usr/local/bin/polkadot \
   --listen-addr=/ip4/127.0.0.1/tcp/{{ p2p_port }} \
   --rpc-methods=Unsafe
 
-Restart=always
-RestartSec=60
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR changes the restart policy of the systemd service. Original configuration restarts node every hour - I guess this was because of OOM issues that used to happen with older versions of Substrate. Since this is not true anymore and nodes can run months without any issues, it makes sense to restart nodes only in case of sudden process kill or other failures. Also, it takes minutes to open RocksDB with the current size of Kusama chain so validators using the current configuration can even be chilled while being in the active set. 

Proposed onfiguration
 - Restart 5 seconds after failure
 - Try to restart five times
 - One minute interval between trials