### PR TITLE
Remove base_path as a default

### DIFF
--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -14,7 +14,7 @@ telemetry_url='wss://telemetry.polkadot.io/submit/,wss://telemetry-backend.w3f.c
 # Only log specify levels, e.g. warnings (optional)
 logging_filter='sync=warn,afg=warn,babe=warn'
 # Location for database, keys, etc (optional)
-base_path='/mnt/volume'
+#base_path='/mnt/volume'
 # Setup a nginx reverse proxy in front of the binary (optional). Disabled by default.
 enable_reverse_proxy = false
 # Any additional flags passed on to the 'polkadot' binary (optional)


### PR DESCRIPTION
The base_path variable was defaulted to /mnt/volume in the inventory.sample file.  This led to some issues for novice users as the path doesn't exist on their host and the service fails to start.  I believe the default path (/home/polkadot/.local/...) should be used in all cases and /mnt/volume be used by exception.