### PR TITLE
Changed default node name

### DIFF
--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -8,7 +8,7 @@
 [validator_0:vars]
 ansible_user=alice
 # Set an individual node name (optional)
-node_name='Alice Validator'
+node_name='Alice_Validator'
 # Setup one or multiple telemetry endpoints (optional)
 telemetry_url='wss://telemetry.polkadot.io/submit/,wss://telemetry-backend.w3f.community/submit'
 # Only log specify levels, e.g. warnings (optional)


### PR DESCRIPTION
In the event that a user doesn't change the default value for node_name he'll encounter an error due to the space.  I've replaced same with an underscore.